### PR TITLE
Make calling deeper nested references hashes work

### DIFF
--- a/test/backend/recursive_lookup_test.rb
+++ b/test/backend/recursive_lookup_test.rb
@@ -19,7 +19,11 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
       :hash_lookup => '${hash}',
       :hash => {
         one: 'hash',
-        other: 'hashes'
+        other: 'hashes',
+        deeper: {
+          first: 'First hash',
+          second: 'Second hash'
+        }
       },
       :number_hash => {
         :format => {
@@ -37,6 +41,10 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
 
   test "still returns an existing translation as usual" do
     assert_equal 'foo', I18n.t(:foo)
+  end
+
+  test "still fails for a missing key" do
+    assert_equal 'translation missing: en.missing_key', I18n.t(:'missing_key')
   end
 
   test "does a lookup on an embedded key" do
@@ -75,11 +83,28 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
 
     assert_equal({
       one: 'hash',
-      other: 'hashes'
+      other: 'hashes',
+      deeper: {
+        first: 'First hash',
+        second: 'Second hash'
+      }
     }, result)
   end
 
   test "correctly translates a hash reference with count" do
     assert_equal 'hashes', I18n.t(:'hash_lookup', count: 5)
+  end
+
+  test "correctly translates a hash reference when called directly" do
+    assert_equal 'hashes', I18n.t(:'hash_lookup.other')
+  end
+
+  test "correctly translates a hash reference when called directly even when nested" do
+    assert_equal 'Second hash', I18n.t(:'hash_lookup.deeper.second')
+  end
+
+  test "correctly fails for a hash reference that is not present" do
+    assert_equal 'translation missing: en.hash_lookup.deeper.not_there.really',
+                 I18n.t(:'hash_lookup.deeper.not_there.really')
   end
 end


### PR DESCRIPTION
Having translations ...

```
a:
  one: One
  two: Two
b: ${a}
```

... it now works to call `I18n.t('b.two')`. Before it missed that
translation if `I18n.t('b')` was not called first.

The way the solution is implemented is experimental and performance
needs to be tested first.